### PR TITLE
adjustments for newer mesos version

### DIFF
--- a/lib/panteras_api/chronos_endpoint.rb
+++ b/lib/panteras_api/chronos_endpoint.rb
@@ -2,7 +2,7 @@ class ChronosEndpoint
   include HTTPUtils
   include Utils
 
-  def initialize(host, port=8080)
+  def initialize(host, port=4400)
     @host = host
     @port = port
   end

--- a/lib/panteras_api/mesos_cluster.rb
+++ b/lib/panteras_api/mesos_cluster.rb
@@ -51,7 +51,7 @@ class MesosCluster
 
   def tasks(framework = nil)
     results = frameworks.collect do |a|
-      if a[:name] == framework
+      if a[:name].include? framework
         a[:tasks].collect { |t| t[:slave_hostname] = slave_hostname_by_id(t[:slave_id]) ; t }
       end
     end
@@ -64,6 +64,11 @@ class MesosCluster
 
   def my_tasks_ids(hostname, framework)
     raise ArgumentError, "missing hostname argument", caller if hostname.nil?
+    # use only the first string before "-" if the task list is empty for framework
+    # this is needed to make sure we use the right framework name for the mesos version
+    if tasks(framework).nil?
+      framework = framework.gsub(/-[^\s]+/,"")
+    end
     new_tasks = tasks(framework)
     if ! new_tasks.nil?
       new_tasks.select { |t| t[:slave_hostname] =~ /^#{hostname}$/ }.collect { |t| t[:id] }


### PR DESCRIPTION
frameworks, i.e. chronos is registered under a different name than before 
used to be “chronos-2.4.0”
is now “chronos”
so if wen don’t get back any tasks, we cut of the version and try again